### PR TITLE
Added sorting keys before checking.

### DIFF
--- a/lib/memory-backend.js
+++ b/lib/memory-backend.js
@@ -35,12 +35,14 @@ MemoryRegexpBakend.prototype.union = function(bucket, keys, cb) {
   var re;
 
   if (!this._buckets[bucket]) {
-    Object.keys(this._buckets).some(function(b) {
-      re = new RegExp('^'+b+'$');
-      match = re.test(bucket);
-      if (match) bucket = b;
-      return match;
-    });
+    Object.keys(this._buckets)
+      .sort()
+      .some(function(b) {
+        re = new RegExp('^'+b+'$');
+        match = re.test(bucket);
+        if (match) bucket = b;
+        return match;
+      });
   }
 
   // [That's a pity...]


### PR DESCRIPTION
The reason is 
```
const roles = [
  {
    roles: ['readonly'],
    allows: [{
      resources: ['/api/v1/user/.*'],
      permissions: ['get'],
    }],
  },
  {
    roles: ['admin'],
    allows: [
      {
        resources: ['/api/v1/user(/.*)?'],
        permissions: ['get', 'put', 'post', 'delete'],
      }
    ],
  },
  {
    roles: ['superadmin'],
    allows: [{
      resources: '.*',
      permissions: '*'
    }]
  }
];
```

Keys of buckets will be incorrectly sorted.

if make a request (role `admin` or `superadmin`):

**DELETE** `/api/v1/user/someid`,

then `union` method will find a wrong `bucket` `/api/v1/user/.*` that has just only one role `readonly`,
but it is not expected behavior.

After keys sorting we have at least the needed `bucket` = `allows_/api/v1/user(/.*)?` or for superadmin `allows_.*`